### PR TITLE
Fix ULID bugs when generating randomness for multiple requests coming in at the exact same timestamp

### DIFF
--- a/src/Nat80.mo
+++ b/src/Nat80.mo
@@ -33,7 +33,7 @@ module {
 	public func add(n80 : Nat80, n : Nat64) : Result.Result<Nat80, Text> {
 		var l = n80.low +% n;
 		var h = n80.high;
-		if (n80.low < l) h +%= 1;
+		if (n80.low > l) h +%= 1;
 		if (n80.high > h) return #err("overflow");
 		#ok({ low = l; high = h; });
 	};

--- a/src/Nat80.mo
+++ b/src/Nat80.mo
@@ -23,7 +23,7 @@ module {
 		let h = Binary.BigEndian.fromNat16(n.high);
 		let l = Binary.BigEndian.fromNat64(n.low);
 		Array.tabulate<Nat8>(
-			6, func (i : Nat) : Nat8 {
+			10, func (i : Nat) : Nat8 {
 				if (i < 2) return h[i];
 				l[i - 2];
 			}
@@ -34,7 +34,7 @@ module {
 		var l = n80.low +% n;
 		var h = n80.high;
 		if (n80.low < l) h +%= 1;
-		if (n80.high < h) return #err("overflow");
+		if (n80.high > h) return #err("overflow");
 		#ok({ low = l; high = h; });
 	};
 


### PR DESCRIPTION
Tagging the maintainer @di-wu and ICDevs @skilesare for potential impacted library dependencies

## Initial Issue

Making at least 2-3 requests that call  the Source new() method at roughly the same time hit an overflow error. This was due to a bug in the following conditional statement.

```
public func add(n80 : Nat80, n : Nat64) : Result.Result<Nat80, Text> {
  var l = n80.low +% n;
  var h = n80.high;
  // l is always greater than n80.low unless the random number being added causes  overflow
  // so we are always incrementing h
  if (n80.low < l) h +%= 1;  
  // here h will pretty much always be greater than n80.high after a single execution, so an "overflow error" will be thrown
  if (n80.high < h) return #err("overflow");
  #ok({ low = l; high = h; });
};
```

[Source of overflow error](https://github.com/aviate-labs/ulid.mo/blob/0229facbf3c59c64ed8b069170de01f8bbb22883/src/Nat80.mo#L37)

## Subsequent Issue

Upon fixing this bug, I encountered an uncaught index out of bounds error [Where index out of bounds error was throwing](https://github.com/aviate-labs/ulid.mo/blob/a1737d9bf1690f58fe2c60b23a844867474e41c4/src/Source.mo#L31)

This was due to the fact that the `Array.append()` method was removed in a subsequent commit and swapped for tabulate, and the size of the array (6) was less than the 10 elements necessary for the random portion of the ulid generation. [Source of index out of bounds error](https://github.com/aviate-labs/ulid.mo/blob/0229facbf3c59c64ed8b069170de01f8bbb22883/src/Nat80.mo#L26).

## Fixes Made

* Correct conditional in Nat80.add() to only give an overflow error when incrementing the h value by 1 causes it to overflow
* Correct Nat80.toArray() to return the full concatenated array from lower and upper Nat80 thresholds, as Source.new() expects a full 16 elements. Note that this is triggered by #ok(Nat80.toArray(e)) in the monotomicRead() method

